### PR TITLE
add extends think-esapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Awesome projects for `ThinkJS 3.x`
 * [think-memcache](https://github.com/thinkjs/think-memcache) Wrap memcache.
 * [think-hashids](https://github.com/weihongyu12/think-hashids) Generate a short unique ID from the integer for ThinkJS
 * [think-purify](https://github.com/weihongyu12/think-purify) Use the HTML5 Purify extension in ThinkJS
+* [think-esapi](https://github.com/weihongyu12/think-esapi) An ESAPI(Enterprise Security API) extend for ThinkJS
 
 ## Projects by ThinkJS
 


### PR DESCRIPTION
Add an extends
think-esapi: an ESAPI(Enterprise Security API) extend for ThinkJS, it is also an effective defense against XSS